### PR TITLE
fixed typo in boilerplate

### DIFF
--- a/BC-Open-Source-Development-Employee-Guide/Licenses.md
+++ b/BC-Open-Source-Development-Employee-Guide/Licenses.md
@@ -83,14 +83,14 @@ Here is the boiler-plate you must put into the comments header of every source c
    
 For repos that are made up of docs, wikis and non-code stuff the default to use is Creative Commons Attribution 4.0 International, and should look like this at the bottom of your README.md:
 
-<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">YOUR REPO NAME HERE</span> by <span xmlns:cc="http://creativecommons.org/ns#" property="cc:attributionName">the Province of Britich Columbia</span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">YOUR REPO NAME HERE</span> by <span xmlns:cc="http://creativecommons.org/ns#" property="cc:attributionName">the Province of British Columbia</span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 
 and the code for the cc 4.0 footer looks like this:
 
     <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence"
     style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br /><span
     xmlns:dct="http://purl.org/dc/terms/" property="dct:title">YOUR REPO NAME HERE</span> by <span
-    xmlns:cc="http://creativecommons.org/ns#" property="cc:attributionName">the Province of Britich Columbia
+    xmlns:cc="http://creativecommons.org/ns#" property="cc:attributionName">the Province of British Columbia
     </span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
     Creative Commons Attribution 4.0 International License</a>.
 


### PR DESCRIPTION
(Britich Columbia -> British Columbia)

Normally not this pedantic, but since this is text meant for users to copy/paste, this error can be propagated through many places!