### PR TITLE
Update link with instructions to invite to org

### DIFF
--- a/BC-Gov-Org-HowTo/Joining-the-BCGov-on-GitHub.md
+++ b/BC-Gov-Org-HowTo/Joining-the-BCGov-on-GitHub.md
@@ -18,7 +18,7 @@ If you're already a GitHub user, you can continue to use this account for Provin
 
 ### Get invited to the org
 
-To be granted permission to create or contribute to a repository in the `bcgov` Github organization, you need to be invited. Ask an existing member iof the `bcgov` GitHub organization to submit an Access Request on your behalf following [these instructions](https://developer.gov.bc.ca/Getting-Started-on-the-DevOps-Platform/How-to-request-new-GitHub-user-access-or-repository-creation).
+To be granted permission to create or contribute to a repository in the `bcgov` Github organization, you need to be invited. Ask an existing member of the `bcgov` GitHub organization to submit an Access Request on your behalf following [these instructions](https://developer.gov.bc.ca/User-access-into-Github-or-Openshift).
 
 Once you are added to the bcgov organization, your membership defaults to "Private". That means that only other members of the bcgov org can see you there. If you want to make your membership known and shown on your profile, follow these <a rel="puborg" href="https://help.github.com/articles/publicizing-or-concealing-organization-membership/"> instructions</a>.
 


### PR DESCRIPTION
This is just saving a couple clicks as the old documentation sends the reader to the `devops-requests` repo, which then sends them to the updated documentation