### PR TITLE
Update the Cheatsheet to align with https://developer.gov.bc.ca

### DIFF
--- a/BC-Gov-Org-HowTo/Cheatsheet.md
+++ b/BC-Gov-Org-HowTo/Cheatsheet.md
@@ -17,7 +17,7 @@ This github.com/bcgov Cheatsheet covers:
 - a few things to help when you are just starting out
 - things to touch base with *every time* you open or contribute to repository as a BC Government employee
 
-All BC Government employees working in bcgov or bcgov-c GitHub should be familiar with the [`GitHub in the BC Government` section of the BC Developer Guide](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/)
+All BC Government employees working in bcgov or bcgov-c GitHub should be familiar with the [_**GitHub in the BC Government**_ section of the BC Developer Guide](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/)
 
 ### Joining github.com/bcgov
 - Create a GitHub account and ensure your [work email is the primary or an alternative email associated with your account](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/adding-an-email-address-to-your-github-account)
@@ -34,11 +34,11 @@ All BC Government employees working in bcgov or bcgov-c GitHub should be familia
 
 ### Creating a Repository (also called a "repo", basically a project)
 -  Choose a path based on whether you are [publishing existing code, initiating a new repository or contributing to an outside repository](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/)
--  If you are publishing **existing code**, [evaluate the content to ensure there are no restrictions (e.g., Privacy, Copyright, Legal contractual or policy, Securiy](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/evaluate-open-source-content/) and confirm [authority to publish](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/)
+-  If you are publishing **existing code**, [evaluate the content to ensure there are no restrictions (e.g., Privacy, Copyright, Legal contractual or policy, Security)](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/evaluate-open-source-content/) and confirm [authority to publish](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/)
 -  If you are initiating a **new repository**, follow [GitHub instructions](https://help.github.com/articles/creating-a-new-repository/), and select 'BCGov' as the owner for all new repositories
-- Pick a repository name that follows best practices, for example following a standard convention (e.g., using lowercase with dashes), descriptive with prefix/suffix for technology stack, use case or team etc.
+- Pick a repository name that follows best practices, for example following a standard naming convention (e.g., using lowercase with dashes), using short and descriptive names with a prefix/suffix indicating technology stack, use case or team
 - Ensure the repo contains the minimum required content (LICENSE, README.md, CONTRIBUTING.md, and CODE_OF_CONDUCT.md files)
-- Consider adding an About description and Topic tags to make it easier for users to learn about the project
+- Consider adding an About description and Topic tags to the repository details to make it easier for users to learn about the project
 - Consider adding a [Project Lifecycle Badge](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 
@@ -62,24 +62,23 @@ All BC Government employees working in bcgov or bcgov-c GitHub should be familia
 - Repositories can have multiple licenses, for example if there is a mix of code and non-code or if the repo contains open datasets under more than one license
 
 ### Privacy, Security & Intellectual Property/Copyright
--  Completing the [Open Content Assessment Checklist](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/Content-Approval-Checklist.md) helps determine if **existing** content can be posted to GitHub by ensuring:
+-  Before publishing any _existing code_ to GitHub, you must evaluate the code to ensure there are no restrictions to posting the content to GitHub (e.g., Privacy, Copyright, Legal contractual or policy, Security)(https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/) by ensuring:
    1. The content is free of [Personal Information](http://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/privacy) (Privacy)
    2. The content has been labelled 'Public' using the  [Information Security Classification Framework](http://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/information-security/information-security-classification-framework) (Security)
    3. The content is fully owned by the B.C. government and/or the B.C. government holds the [Intellectual Property/Copyright](http://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property) for the content
    4. There are no other legal, contractual or policy constraints
-- Read more about privacy, security and intellectual property in the [BC-Policy-Framework-For-GitHub](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/COI-Priv-IP.md)
+- Read more about assessing privacy, security and intellectual property in the [BC Developer Guide]](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/evaluate-open-source-content/)
 
 
 ### Approval Requirements
--  Approvals and minium requirements are set out in the [Open Development Standard (pages 14-15)](http://www2.gov.bc.ca/assets/gov/government/services-for-government-and-broader-public-sector/information-technology-services/standards-files/development_standards_for_information_systems_and_services.pdf)
--  BC Government employees are responsible for adhering to any Ministry-specific approvals for working in GitHub
+-  You should get [approval for publishing to GitHub]((https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/)) from your deputy minister. Deputy ministers may choose to delegate this authority to ministry chief information officers (CIOs).
+-  BC Government employees are responsible for adhering to any Ministry-specific approval processes for working in GitHub
 
 
 ### Appropriate Use 
 - When you’re consuming, sharing or contributing content to GitHub in your role as a government employee, you must adhere to the [BC Public Service Standards of Conduct](http://www2.gov.bc.ca/gov/content/careers-myhr/managers-supervisors/employee-labour-relations/conditions-agreements/policy#standards)
 - It is essential that [employees avoid any conflicts of interest when using GitHub](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/COI-Priv-IP.md), and personal use of GitHub must never be confused with professional use
 - Make sure you're familiar with existing [OCIO policy on information security](http://www2.gov.bc.ca/gov/content?id=BB7D7F3938634BF2973BDE1A899FB755) before downloading or testing any code
-- Be familiar with and follow the various [Appropriate Use](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/appropriate-use.md) policies, such as the [Social Media Guidelines](http://www.gov.bc.ca/citz/citizens_engagement/some_guidelines_master.pdf) and the [Open Development Standards](http://www2.gov.bc.ca/assets/gov/government/services-for-government-and-broader-public-sector/information-technology-services/standards-files/development_standards_for_information_systems_and_services.pdf)
 
 
 

--- a/BC-Gov-Org-HowTo/Cheatsheet.md
+++ b/BC-Gov-Org-HowTo/Cheatsheet.md
@@ -17,7 +17,7 @@ This github.com/bcgov Cheatsheet covers:
 - a few things to help when you are just starting out
 - things to touch base with *every time* you open or contribute to a code repository as a BC Government employee
 
-All BC Government employees working in bcgov (or bcgov-c) GitHub should be familiar with the [**GitHub in the BC Government**] section of the BC Developer Guide(https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/bc-government-organizations-in-github/) 
+All BC Government employees working in bcgov (or bcgov-c) GitHub should be familiar with the [**GitHub in the BC Government**] (https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/bc-government-organizations-in-github/) section of the BC Developer Guide 
 
 
 ### Joining github.com/bcgov

--- a/BC-Gov-Org-HowTo/Cheatsheet.md
+++ b/BC-Gov-Org-HowTo/Cheatsheet.md
@@ -15,9 +15,10 @@ tags:
 This github.com/bcgov Cheatsheet covers:
 
 - a few things to help when you are just starting out
-- things to touch base with *every time* you open or contribute to repository as a BC Government employee
+- things to touch base with *every time* you open or contribute to a code repository as a BC Government employee
 
-All BC Government employees working in bcgov or bcgov-c GitHub should be familiar with the [**GitHub in the BC Government** section of the BC Developer Guide](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/)
+All BC Government employees working in bcgov (or bcgov-c) GitHub should be familiar with the [**GitHub in the BC Government** section of the BC Developer Guide](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/bc-government-organizations-in-github/) 
+
 
 ### Joining github.com/bcgov
 - Create a GitHub account and ensure your [work email is the primary or an alternative email associated with your account](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/adding-an-email-address-to-your-github-account)
@@ -34,8 +35,8 @@ All BC Government employees working in bcgov or bcgov-c GitHub should be familia
 
 ### Creating a Repository (also called a "repo", basically a project)
 -  Choose a path based on whether you are [publishing existing code, initiating a new repository or contributing to an outside repository](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/)
--  If you are publishing **existing code**, [evaluate the content to ensure there are no restrictions (e.g., Privacy, Copyright, Legal contractual or policy, Security)](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/evaluate-open-source-content/) and confirm [authority to publish](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/)
--  If you are initiating a **new repository**, follow [GitHub instructions](https://help.github.com/articles/creating-a-new-repository/), and select 'BCGov' as the owner for all new repositories
+-  If you are publishing **existing code**, [evaluate the content to ensure there are no restrictions](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/#post-existing-code-or-projects) (e.g., Privacy, Copyright, Legal contractual or policy, Security) and confirm [authority to publish](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/license-your-github-repository/#authority-to-license)
+-  If you are initiating a **new repository**, follow [GitHub instructions](https://help.github.com/articles/creating-a-new-repository/) and select 'BCGov' as the owner for all new repositories and implement the [required elements](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/#initiate-new-code-or-projects) of all bcgov repositories
 - Pick a repository name that follows best practices, for example following a standard naming convention (e.g., using lowercase with dashes), using short and descriptive names with a prefix/suffix indicating technology stack, use case or team
 - Ensure the repo contains the minimum required content (LICENSE, README.md, CONTRIBUTING.md, and CODE_OF_CONDUCT.md files)
 - Consider adding an About description and Topic tags to the repository details to make it easier for users to learn about the project
@@ -53,7 +54,7 @@ All BC Government employees working in bcgov or bcgov-c GitHub should be familia
 
 ### How to License the Contents of a Repository
 - Ensure [authority to LICENSE](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/license-your-github-repository/) the code and other non-code content in the repository
-- Choose [a LICENSE](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/license-your-github-repository/) for your code (.md files are considered code). The default is the Apache 2.0 LICENSE
+- Choose [a LICENSE](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/license-your-github-repository/#preferred-licenses) for your code (.md files are considered code). The default is the Apache 2.0 LICENSE
 - Apply the Apache 2.0 LICENSE in 1-2-3 easy steps:
    1. Attach appropriate LICENSE file directly in the repository
    2. Add the boiler-plate Apache 2.0 LICENSE to the the bottom of your README.md

--- a/BC-Gov-Org-HowTo/Cheatsheet.md
+++ b/BC-Gov-Org-HowTo/Cheatsheet.md
@@ -17,7 +17,7 @@ This github.com/bcgov Cheatsheet covers:
 - a few things to help when you are just starting out
 - things to touch base with *every time* you open or contribute to repository as a BC Government employee
 
-All BC Government employees working in bcgov or bcgov-c GitHub should be familiar with the [_**GitHub in the BC Government**_ section of the BC Developer Guide](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/)
+All BC Government employees working in bcgov or bcgov-c GitHub should be familiar with the [**GitHub in the BC Government** section of the BC Developer Guide](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/)
 
 ### Joining github.com/bcgov
 - Create a GitHub account and ensure your [work email is the primary or an alternative email associated with your account](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/adding-an-email-address-to-your-github-account)
@@ -62,16 +62,16 @@ All BC Government employees working in bcgov or bcgov-c GitHub should be familia
 - Repositories can have multiple licenses, for example if there is a mix of code and non-code or if the repo contains open datasets under more than one license
 
 ### Privacy, Security & Intellectual Property/Copyright
--  Before publishing any _existing code_ to GitHub, you must evaluate the code to ensure there are no restrictions to posting the content to GitHub (e.g., Privacy, Copyright, Legal contractual or policy, Security)(https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/) by ensuring:
+-  Before publishing any _existing code_ to GitHub, you must [evaluate the code to ensure there are no restrictions to posting the content to GitHub](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/) (e.g., Privacy, Copyright, Legal contractual or policy, Security) by ensuring:
    1. The content is free of [Personal Information](http://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/privacy) (Privacy)
    2. The content has been labelled 'Public' using the  [Information Security Classification Framework](http://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/information-security/information-security-classification-framework) (Security)
    3. The content is fully owned by the B.C. government and/or the B.C. government holds the [Intellectual Property/Copyright](http://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property) for the content
    4. There are no other legal, contractual or policy constraints
-- Read more about assessing privacy, security and intellectual property in the [BC Developer Guide]](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/evaluate-open-source-content/)
+- Read more about assessing privacy, security and intellectual property in the [BC Developer Guide](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/evaluate-open-source-content/)
 
 
 ### Approval Requirements
--  You should get [approval for publishing to GitHub]((https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/)) from your deputy minister. Deputy ministers may choose to delegate this authority to ministry chief information officers (CIOs).
+-  You should get [approval for publishing to GitHub](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/) from your deputy minister. Deputy ministers may choose to delegate this authority.
 -  BC Government employees are responsible for adhering to any Ministry-specific approval processes for working in GitHub
 
 

--- a/BC-Gov-Org-HowTo/Cheatsheet.md
+++ b/BC-Gov-Org-HowTo/Cheatsheet.md
@@ -71,8 +71,8 @@ All BC Government employees working in bcgov or bcgov-c GitHub should be familia
 
 
 ### Approval Requirements
--  You should get [approval for publishing to GitHub](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/) from your deputy minister. Deputy ministers may choose to delegate this authority.
--  BC Government employees are responsible for adhering to any Ministry-specific approval processes for working in GitHub
+-  [Approval for publishing to GitHub](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/) are from the deputy minister. Deputy ministers may choose to delegate this authority.
+-  BC Government employees are responsible for adhering to any Ministry or project-specific approval processes for working in GitHub
 
 
 ### Appropriate Use 

--- a/BC-Gov-Org-HowTo/Cheatsheet.md
+++ b/BC-Gov-Org-HowTo/Cheatsheet.md
@@ -17,7 +17,7 @@ This github.com/bcgov Cheatsheet covers:
 - a few things to help when you are just starting out
 - things to touch base with *every time* you open or contribute to a code repository as a BC Government employee
 
-All BC Government employees working in bcgov (or bcgov-c) GitHub should be familiar with the [**GitHub in the BC Government**] (https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/bc-government-organizations-in-github/) section of the BC Developer Guide 
+All BC Government employees working in bcgov (or bcgov-c) GitHub should be familiar with the [**GitHub in the BC Government**](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/bc-government-organizations-in-github/) section of the BC Developer Guide 
 
 
 ### Joining github.com/bcgov
@@ -36,7 +36,7 @@ All BC Government employees working in bcgov (or bcgov-c) GitHub should be famil
 ### Creating a Repository (also called a "repo", basically a project)
 -  Choose a path based on whether you are [publishing existing code, initiating a new repository or contributing to an outside repository](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/)
 -  If you are publishing **existing code**, [evaluate the content to ensure there are no restrictions](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/#post-existing-code-or-projects) (e.g., Privacy, Copyright, Legal contractual or policy, Security) and confirm [authority to publish](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/license-your-github-repository/#authority-to-license)
--  If you are initiating a **new repository**, follow [GitHub instructions](https://help.github.com/articles/creating-a-new-repository/) and select 'BCGov' as the owner for all new repositories and implement the [required elements](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/#initiate-new-code-or-projects) of all bcgov repositories
+-  If you are initiating a **new repository**, follow [GitHub instructions](https://help.github.com/articles/creating-a-new-repository/) and select 'BCGov' as the owner for all new repositories and implement the [required elements](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/#initiate-new-code-or-projects)
 - Pick a repository name that follows best practices, for example following a standard naming convention (e.g., using lowercase with dashes), using short and descriptive names with a prefix/suffix indicating technology stack, use case or team
 - Ensure the repo contains the minimum required content (LICENSE, README.md, CONTRIBUTING.md, and CODE_OF_CONDUCT.md files)
 - Consider adding an About description and Topic tags to the repository details to make it easier for users to learn about the project
@@ -77,7 +77,7 @@ All BC Government employees working in bcgov (or bcgov-c) GitHub should be famil
 
 
 ### Appropriate Use 
-- When you’re consuming, sharing or contributing content to GitHub in your role as a government employee, you must adhere to the [BC Public Service Standards of Conduct](http://www2.gov.bc.ca/gov/content/careers-myhr/managers-supervisors/employee-labour-relations/conditions-agreements/policy#standards)
+- When you’re consuming, sharing or contributing content to GitHub in your role as a government employee, you must adhere to the [BC Public Service Standards of Conduct](https://www2.gov.bc.ca/gov/content?id=0F130A55BFDD4DA1B0ED7FA0AC8D3041)
 - It is essential that [employees avoid any conflicts of interest when using GitHub](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/COI-Priv-IP.md), and personal use of GitHub must never be confused with professional use
 - Make sure you're familiar with existing [OCIO policy on information security](http://www2.gov.bc.ca/gov/content?id=BB7D7F3938634BF2973BDE1A899FB755) before downloading or testing any code
 

--- a/BC-Gov-Org-HowTo/Cheatsheet.md
+++ b/BC-Gov-Org-HowTo/Cheatsheet.md
@@ -17,7 +17,7 @@ This github.com/bcgov Cheatsheet covers:
 - a few things to help when you are just starting out
 - things to touch base with *every time* you open or contribute to a code repository as a BC Government employee
 
-All BC Government employees working in bcgov (or bcgov-c) GitHub should be familiar with the [**GitHub in the BC Government** section of the BC Developer Guide](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/bc-government-organizations-in-github/) 
+All BC Government employees working in bcgov (or bcgov-c) GitHub should be familiar with the [**GitHub in the BC Government**] section of the BC Developer Guide(https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/bc-government-organizations-in-github/) 
 
 
 ### Joining github.com/bcgov
@@ -63,10 +63,10 @@ All BC Government employees working in bcgov (or bcgov-c) GitHub should be famil
 - Repositories can have multiple licenses, for example if there is a mix of code and non-code or if the repo contains open datasets under more than one license
 
 ### Privacy, Security & Intellectual Property/Copyright
--  Before publishing any _existing code_ to GitHub, you must [evaluate the code to ensure there are no restrictions to posting the content to GitHub](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/) (e.g., Privacy, Copyright, Legal contractual or policy, Security) by ensuring:
+-  Before publishing any _existing code_ to GitHub, you must [evaluate the code to ensure there are no restrictions to posting the content to GitHub](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/evaluate-open-source-content/) (e.g., Privacy, Copyright, Legal contractual or policy, Security) by ensuring:
    1. The content is free of [Personal Information](http://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/privacy) (Privacy)
-   2. The content has been labelled 'Public' using the  [Information Security Classification Framework](http://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/information-security/information-security-classification-framework) (Security)
-   3. The content is fully owned by the B.C. government and/or the B.C. government holds the [Intellectual Property/Copyright](http://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property) for the content
+   2. The content has been labelled 'Public' using the  [Information Security Classification Framework](https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/information-security/information-security-classification) (Security)
+   3. The content is fully owned by the B.C. government and/or the B.C. government holds the [Intellectual Property and Copyright](https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property/intellectual-property-program) for the content
    4. There are no other legal, contractual or policy constraints
 - Read more about assessing privacy, security and intellectual property in the [BC Developer Guide](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/evaluate-open-source-content/)
 

--- a/BC-Gov-Org-HowTo/Cheatsheet.md
+++ b/BC-Gov-Org-HowTo/Cheatsheet.md
@@ -1,4 +1,4 @@
----
+<!--
 description: A list of tips, tricks and best practices for using GitHub as a code repository for government projects.
 tags:
 - GitHub
@@ -8,59 +8,61 @@ tags:
 - license
 - application development
 - guidelines
----
+-->
+
 ## "Working in github.com/bcgov" Cheatsheet
 
 This github.com/bcgov Cheatsheet covers:
 
 - a few things to help when you are just starting out
-- things to touch base with *every time* you open or contribute to repository (as a BC Government employee)
+- things to touch base with *every time* you open or contribute to repository as a BC Government employee
 
- All BC Government employees working in github.com/bcgov should be familiar with the full [BC-Policy-Framework-For-GitHub](https://github.com/bcgov/BC-Policy-Framework-For-GitHub)
-
+All BC Government employees working in bcgov or bcgov-c GitHub should be familiar with the [`GitHub in the BC Government` section of the BC Developer Guide](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/)
 
 ### Joining github.com/bcgov
-- Create a GitHub account with your work email and "Province of British Columbia" as the company (optional)
+- Create a GitHub account and ensure your [work email is the primary or an alternative email associated with your account](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/adding-an-email-address-to-your-github-account)
 - Enable [two-factor authentication](https://help.github.com/articles/about-two-factor-authentication/) for your GitHub account
-- Join the BCGov Organization (follow [these instructions](https://developer.gov.bc.ca/Getting-Started-on-the-DevOps-Platform/How-to-request-new-GitHub-user-access-or-repository-creation)) 
+- Join the BCGov Organization: follow [these instructions](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/bc-government-organizations-in-github/#directions-to-sign-up-and-link-your-account-for-bcgov) 
 - Make sure you have [Git](https://git-scm.com/) installed on your computer
 
 
 ### Some Resources for Learning Git & GitHub
-- [Git and GitHub are not the same thing](https://jahya.net/blog/git-vs-github/)
+- [About Git and GitHub](https://docs.github.com/en/get-started/start-your-journey/about-github-and-git)
 - [Learn Git in 15 minutes](https://try.github.io/levels/1/challenges/1)
 - [On-demand course in GitHub basics](https://skills.github.com)
 
 
 ### Creating a Repository (also called a "repo", basically a project)
--  Choose a path based on whether you are [publishing existing code, initiating a new repository or contributing to an outside repository](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/Collaborating-Contributing.md)
--  Complete your [Open Content Assessment Checklist](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/Content-Approval-Checklist.md)
--  Follow [GitHub instructions](https://help.github.com/articles/creating-a-new-repository/), and select 'BCGov' as the owner for all new repositories
--  Pick a repository name that follows [best practices](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Gov-Org-HowTo/Naming-Repos.md)&mdash;for example typically using lowercase with dashes
--  Ensure the repo contains the minimum required content (LICENSE, README.md, CONTRIBUTING.md files)
+-  Choose a path based on whether you are [publishing existing code, initiating a new repository or contributing to an outside repository](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/)
+-  If you are publishing **existing code**, [evaluate the content to ensure there are no restrictions (e.g., Privacy, Copyright, Legal contractual or policy, Securiy](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/evaluate-open-source-content/) and confirm [authority to publish](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/)
+-  If you are initiating a **new repository**, follow [GitHub instructions](https://help.github.com/articles/creating-a-new-repository/), and select 'BCGov' as the owner for all new repositories
+- Pick a repository name that follows best practices, for example following a standard convention (e.g., using lowercase with dashes), descriptive with prefix/suffix for technology stack, use case or team etc.
+- Ensure the repo contains the minimum required content (LICENSE, README.md, CONTRIBUTING.md, and CODE_OF_CONDUCT.md files)
+- Consider adding an About description and Topic tags to make it easier for users to learn about the project
+- Consider adding a [Project Lifecycle Badge](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 
 ### ALL github.com/bcgov Repositories
-- Every github.com/bcgov repo must have 3 items:
-   1. LICENSE file
-   2. README file
-   3. CONTRIBUTING file
-- Adding a [Contributor Code of Conduct](http://contributor-covenant.org/) to your repository is [highly encouraged](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/Collaborating-Contributing.md)
+- Every github.com/bcgov repo [must have 4 files](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/required-pages-for-github-repository/):
+   1. LICENSE
+   2. README.md
+   3. CONTRIBUTING.md
+   4. CODE_OF_CONDUCT.md
 - [Sample templates](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Gov-Org-HowTo/README.md) are available for all of these 'must have' files
 
 
 ### How to License the Contents of a Repository
-- Ensure [authority to LICENSE](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/Licenses.md) the code and other non-code content in the repository
-- Choose [a LICENSE](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/Licenses.md) for your code (.md files are considered code). The default is the Apache 2.0 LICENSE
+- Ensure [authority to LICENSE](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/license-your-github-repository/) the code and other non-code content in the repository
+- Choose [a LICENSE](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/license-your-github-repository/) for your code (.md files are considered code). The default is the Apache 2.0 LICENSE
 - Apply the Apache 2.0 LICENSE in 1-2-3 easy steps:
    1. Attach appropriate LICENSE file directly in the repository
    2. Add the boiler-plate Apache 2.0 LICENSE to the the bottom of your README.md
-   3. Add the boiler-plate Apache 2.0 LICENSE to the comments header of *every source code file* 
+   3. Add the boiler-plate Apache 2.0 LICENSE to the comments header of _**every source code file**_ 
 - Choose a license for any other content (e.g. docs, wikis and non-code stuff) &mdash;the default is [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)&mdash;and add to the footer of your README.md
 - Repositories can have multiple licenses, for example if there is a mix of code and non-code or if the repo contains open datasets under more than one license
 
 ### Privacy, Security & Intellectual Property/Copyright
--  Completing the [Open Content Assessment Checklist](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/Content-Approval-Checklist.md) helps determine if content can be posted to GitHub by ensuring:
+-  Completing the [Open Content Assessment Checklist](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Open-Source-Development-Employee-Guide/Content-Approval-Checklist.md) helps determine if **existing** content can be posted to GitHub by ensuring:
    1. The content is free of [Personal Information](http://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/privacy) (Privacy)
    2. The content has been labelled 'Public' using the  [Information Security Classification Framework](http://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/information-security/information-security-classification-framework) (Security)
    3. The content is fully owned by the B.C. government and/or the B.C. government holds the [Intellectual Property/Copyright](http://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property) for the content


### PR DESCRIPTION
A PR to update + align the Cheatsheet to reflect content in the BC Developer Guide, the more up-to-date location for bcgov and bcgov-c docs, and direct readers to these pages instead of pages in this repo where appropriate:

- updates urls to Develop Guide pages where they exist/replace repo pages
- update sign-up instructions 
- remove or update URLs throughout
- remove reference to checklist and replace with "evaluate your code" 
- change instructions re: CODE_of_CONDUCT.md being a mandatory file (was optional)

Context: my team at BC Stats use this cheatsheet frequently and find it very helpful for onboarding. We would like to continue to use this and have offered this PR to ensure the advice in the Cheatsheet is up-to-date and aligns with the new docs. A more long-term solution might be to create a Cheatsheet in the BC Developer Guide repo (which I would be happy to do if there is appetite) and retire or deprecate this content.