### PR TITLE
DEVXT-1959 - Add Backstage catalog-info to register repo with DevHub

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "bc-policy-framework-for-github"
+  title: "BC Gov Policy Framework for GitHub"
+  description: "Policy and guidelines for BC Government employees using GitHub, including the Employee Guide, How-To's, and the bcgov GitHub Cheatsheet."
+  annotations:
+    github.com/project-slug: bcgov/BC-Policy-Framework-For-GitHub
+  tags:
+    - github
+    - policy
+    - open-source
+    - guidelines
+    - employee-guide
+spec:
+  type: documentation
+  lifecycle: production
+  owner: group:developer-experience


### PR DESCRIPTION
Adds a Backstage `catalog-info.yaml` at the repo root so this policy framework can be registered in DevHub (https://developer.gov.bc.ca) and show up in search.                                                                                                                                                                    
                                                            
Right now the doc isn't discoverable on DevHub. If you search for "GitHub policy" or "open source guidelines", nothing comes back. This file is the first half of fixing that. The second half is a companion PR in `bcgov/developer-experience-team` that adds this file's URL to the DevHub catalog seed.